### PR TITLE
Feat/1 selected marker UI(選択されている場所が分かりにくい)

### DIFF
--- a/src/Map.css
+++ b/src/Map.css
@@ -5,3 +5,7 @@
     height: 100%;
     width: 100%;
 }
+
+.leaflet-marker-icon.selected-marker {
+    filter: hue-rotate(180deg) saturate(1.25) brightness(1.05);
+}

--- a/src/SpotItem.css
+++ b/src/SpotItem.css
@@ -1,5 +1,7 @@
 .spotItem {
     border-radius: 10px;
+    border: 1px solid transparent;
+    box-sizing: border-box;
 }
 
 .spotItem:hover {
@@ -7,20 +9,9 @@
     background-color: #f0f0f0;
 }
 
-.spotItem.blink-highlight {
-    animation: blink-bg 1.2s ease-in-out 1;
-}
-
-@keyframes blink-bg {
-    0% {
-        background-color: rgba(0, 0, 0, 0);
-    }
-    10% {
-        background-color: rgba(255, 243, 82, 1);
-    }
-    100% {
-        background-color: rgba(0, 0, 0, 0);
-    }
+.spotItem.selected {
+    background-color: rgba(255, 107, 0, 0.15);
+    border-color: rgba(255, 107, 0, 0.9);
 }
 
 .spotTitle {

--- a/src/SpotItem.tsx
+++ b/src/SpotItem.tsx
@@ -1,5 +1,5 @@
 import type { Feature, Geometry } from "geojson";
-import { useEffect, useRef } from "react";
+import { useMemo } from "react";
 import LiteYouTubeEmbed from 'react-lite-youtube-embed';
 import 'react-lite-youtube-embed/dist/LiteYouTubeEmbed.css';
 import type { RowComponentProps } from "react-window";
@@ -16,18 +16,7 @@ function SpotItem({ index, features, style }: RowComponentProps<ListItemProps>) 
   const properties = feature.properties;
   const isClosed = properties.isClosed;
   const {selectedId, select} = useLocationSelection();
-  const spotItemRootRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    if (selectedId !== feature.id || !spotItemRootRef.current) return;
-    const spotItemRef = spotItemRootRef.current;
-    spotItemRef.classList.add("blink-highlight");
-    const t = setTimeout(() => spotItemRef.classList.remove("blink-highlight"), 1500);
-    return () => {
-      spotItemRef.classList.remove("blink-highlight");
-      clearTimeout(t);
-    };
-  }, [selectedId, feature.id]);
+  const isSelected = useMemo(() => selectedId === feature.id, [selectedId, feature.id]);
 
   function onClickSpotItem() {
     if (isClosed) return;
@@ -35,7 +24,11 @@ function SpotItem({ index, features, style }: RowComponentProps<ListItemProps>) 
   }
 
   return (
-    <div ref={spotItemRootRef} className={`spotItem${isClosed ? ' closed' : ''}`} onClick={onClickSpotItem} style={style}>
+    <div
+      className={`spotItem${isClosed ? " closed" : ""}${isSelected ? " selected" : ""}`}
+      onClick={onClickSpotItem}
+      style={style}
+    >
       <span className="spotTitle">
         <span>{properties.name}</span>
         {isClosed ? <span className="closedBadge">閉業</span> : null}


### PR DESCRIPTION
## 概要
選択されている場所が分かりにくいため表示を変更した。

## 関連Issue
Closes #1 

## 変更
- 選択中のスポットをリスト側で「薄い背景色＋外枠」で強調するように変更
- マップの選択中ピンは既存PNGにCSSフィルターを当てて色味を変更
- 選択中ピンは少し大きく表示するように調整

## メモ
Issueにも貼り付けた通り、以下のような見た目に変更
<img width="1918" height="945" alt="image" src="https://github.com/user-attachments/assets/9b018f97-68b7-4cc2-8dcf-4fcdff7808e6" />
