### PR TITLE
Fix/13 wrong pan(指定したスポットへのpanがされない)

### DIFF
--- a/src/CurrentLocationMarker.tsx
+++ b/src/CurrentLocationMarker.tsx
@@ -3,6 +3,7 @@ import "leaflet/dist/leaflet.css";
 import { useEffect, useState } from 'react';
 import { Marker, useMapEvents } from 'react-leaflet';
 import currentLocationIcon from "./assets/img/current_location.webp";
+import { spotsData } from "./mapData";
 import { useLocationSelection } from "./locationSelectionContext";
 
 // Define custom icon for current location marker
@@ -18,12 +19,15 @@ function CurrentLocationMarker() {
   const [position, setPosition] = useState<LatLng | null>(null);
   const [isInitMapPan, setIsInitMapPan] = useState<boolean>(false);
   const { selectedId } = useLocationSelection();
+  const hasValidSelection =
+    selectedId !== null &&
+    spotsData.features.some((feature) => feature.id === selectedId);
 
   // Set up map events to track location
   const map = useMapEvents({
     locationfound(event) {
       setPosition(event.latlng);
-      if (isInitMapPan || selectedId) return;
+      if (isInitMapPan || hasValidSelection) return;
       setIsInitMapPan(true);
       map.panTo(event.latlng);
     }


### PR DESCRIPTION
# 概要 / Summary
Issue #13の対応
位置情報アクセス許可時、且つspotIdがURLパラメータで指定されている場合は現在地にpanされないようにする。

## 関連Issue / Related Issue(s)
Close #13 

## 変更内容 / Changes
・spotId指定時は現在地取得の自動panを抑制するようにした。

## 影響範囲 / Impact
読込時のMap初期化

## 備考 / Notes
無し

## チェックリスト / Checklist
<!-- PRを提出する前に以下の項目を確認してください。 -->
<!-- Confirm the following before submitting the PR. -->
- [x] 文法エラーがないことを確認しました。 <!-- Confirmed there are no grammar mistakes. -->
- [x] 動作確認を行いました。 <!-- Verified functionality locally. -->
- [x] タイトルと説明が適切であることを確認しました。 <!-- Confirmed title and description are appropriate. -->
- [x] 関連するIssueをリンクしました。 <!-- Linked related issue(s). -->